### PR TITLE
Translate hompage

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -2,24 +2,27 @@ import React, { createContext, useContext, useState } from 'react'
 
 interface ContextData {
   language: string
-  selectLanguage(language: string): void // eslint-disable-line
+  selectPortuguese(): void
+  selectEnglish(): void
+  selectSpanish(): void
 }
 
 const LanguageContext = createContext<ContextData>({} as ContextData)
 
+const LANGUAGE_OPTIONS = {
+  pt: 'pt',
+  en: 'en',
+  es: 'es',
+}
+
 export const LanguageProvider = ({ children }: { children: React.ReactNode }) => {
-  const LANGUAGE_OPTIONS = {
-    pt: 'pt',
-    en: 'en',
-    es: 'es',
-  }
-
   const [language, setLanguage] = useState(LANGUAGE_OPTIONS.pt)
-
-  const selectLanguage = (lang: string) => setLanguage(lang)
+  const selectPortuguese = () => setLanguage(LANGUAGE_OPTIONS.pt)
+  const selectEnglish = () => setLanguage(LANGUAGE_OPTIONS.en)
+  const selectSpanish = () => setLanguage(LANGUAGE_OPTIONS.es)
 
   return (
-    <LanguageContext.Provider value={{ language, selectLanguage }}>
+    <LanguageContext.Provider value={{ language, selectPortuguese, selectEnglish, selectSpanish }}>
       {children}
     </LanguageContext.Provider>
   )

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -5,11 +5,20 @@ import { Game } from 'types'
 import Button from 'components/Button'
 import Carousel from 'components/Carousel'
 import gameList from 'assets/texts/games'
+import { useLanguage } from 'contexts/LanguageContext'
+import { english, portuguese } from './text'
 import * as S from './styles'
 
+const TEXTS: any = {
+  pt: portuguese,
+  en: english,
+}
+
 export default function Home() {
-  const { push } = useHistory()
   const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+  const [text, setText] = useState(portuguese)
+  const { push } = useHistory()
+  const { language, selectEnglish, selectPortuguese } = useLanguage()
 
   const isMobileScreen = useMemo(() => windowWidth <= 800, [windowWidth])
 
@@ -21,8 +30,8 @@ export default function Home() {
 
   const renderTitle = () => (
     <>
-      <S.Title>Jogos de improvisação</S.Title>
-      <S.SubTitle>para violoncelistas iniciantes</S.SubTitle>
+      <S.Title>{text.title}</S.Title>
+      <S.SubTitle>{text.subtitle}</S.SubTitle>
     </>
   )
 
@@ -30,9 +39,9 @@ export default function Home() {
     <>
       <S.Image />
       <S.Links>
-        <S.Link onClick={() => push('quarantine-games')}>Sons da quarentena</S.Link>
-        <S.Link onClick={() => push('about')}>Saiba mais</S.Link>
-        <S.Link onClick={() => push('article')}>Caderno de atividades</S.Link>
+        <S.Link onClick={() => push('quarantine-games')}>{text.quarantineLink}</S.Link>
+        <S.Link onClick={() => push('about')}>{text.aboutLink}</S.Link>
+        <S.Link onClick={() => push('article')}>{text.articleLink}</S.Link>
       </S.Links>
     </>
   )
@@ -40,6 +49,12 @@ export default function Home() {
   const updateWindowWidth = useCallback(() => {
     setWindowWidth(window.innerWidth)
   }, [])
+
+  const handleLanguage = useCallback(() => setText(TEXTS[`${language}`]), [language])
+
+  useEffect(() => {
+    handleLanguage()
+  }, [handleLanguage])
 
   useEffect(() => {
     window.addEventListener('resize', updateWindowWidth)
@@ -70,6 +85,20 @@ export default function Home() {
           </>
         )}
       </S.Container>
+      <button
+        style={{ height: '50px', width: '200px' }}
+        type="button"
+        onClick={() => selectPortuguese()}
+      >
+        Portugues
+      </button>
+      <button
+        style={{ height: '50px', width: '200px' }}
+        type="button"
+        onClick={() => selectEnglish()}
+      >
+        English
+      </button>
     </S.Wrapper>
   )
 }

--- a/src/pages/Home/text.ts
+++ b/src/pages/Home/text.ts
@@ -1,0 +1,23 @@
+export type TextType = {
+  title: string
+  subtitle: string
+  quarantineLink: string
+  aboutLink: string
+  articleLink: string
+}
+
+export const portuguese = {
+  title: 'Jogos de improvisação',
+  subtitle: 'para violoncelistas iniciantes',
+  quarantineLink: 'Sons da quarentena',
+  aboutLink: 'Saiba mais',
+  articleLink: 'Caderno de atividades',
+} as TextType
+
+export const english = {
+  title: 'Improvisation games',
+  subtitle: 'for beginner cellists',
+  quarantineLink: 'Quarantine sounds',
+  aboutLink: 'About',
+  articleLink: 'Article',
+} as TextType


### PR DESCRIPTION
## Purpose :dart:

Add the option to the English translation of the homepage.

## Technical details :nerd_face:

Some updates were made on the LanguageContext for better use purposes.

## Screenshots :framed_picture:

![image](https://user-images.githubusercontent.com/18143403/164608987-633b4ee1-9c07-4e92-8a23-f1d94b96a5bd.png)


## Checklist :ballot_box_with_check:

- [x] `Purpose`
- [ ] `Technical details`
- [ ] `Screenshots`
